### PR TITLE
fix: sync community filters with URL query params

### DIFF
--- a/app/pages/communautes/index.vue
+++ b/app/pages/communautes/index.vue
@@ -72,18 +72,23 @@
 import type { FilterOptions, CommunityCard, PaginatedResponse } from '#shared/types'
 
 const route = useRoute()
+const router = useRouter()
+
+function splitParam(key: string): string[] {
+  return route.query[key] ? (route.query[key] as string).split(',') : []
+}
 
 const filters = ref<FilterOptions>({
   search: (route.query.search as string) || '',
-  modules: route.query.modules ? (route.query.modules as string).split(',') : [],
-  communityType: [],
-  sizeCategory: [],
-  recruitmentStatus: [],
-  eventFrequency: [],
-  historicalPeriods: [],
-  experiences: [],
-  sort: 'name',
-  sortDir: 'asc',
+  modules: splitParam('modules'),
+  communityType: splitParam('communityType'),
+  sizeCategory: splitParam('sizeCategory'),
+  recruitmentStatus: splitParam('recruitmentStatus'),
+  eventFrequency: splitParam('eventFrequency'),
+  historicalPeriods: splitParam('historicalPeriods'),
+  experiences: splitParam('experiences'),
+  sort: (route.query.sort as string) || 'name',
+  sortDir: (route.query.sortDir as 'asc' | 'desc') || 'asc',
   limit: 50,
 })
 
@@ -128,6 +133,10 @@ useSeoMeta({
 })
 watch(filters, () => {
   currentPage.value = 1
+}, { deep: true })
+
+watch(queryParams, (params) => {
+  router.replace({ query: params })
 }, { deep: true })
 
 function resetFilters() {


### PR DESCRIPTION
## Problème

Sur la page `/communautes`, les filtres n'étaient pas correctement synchronisés avec l'URL :

- Seuls `search` et `modules` étaient restaurés depuis `route.query` au chargement — les 6 autres dimensions (`communityType`, `sizeCategory`, `recruitmentStatus`, `eventFrequency`, `historicalPeriods`, `experiences`) et les options de tri étaient perdues.
- Quand on changeait un filtre, l'URL **n'était jamais mise à jour**, donc un lien partagé ignorait tous les filtres actifs.

## Solution

- Lecture de tous les paramètres de filtre depuis `route.query` à l'initialisation via un helper `splitParam`.
- Ajout d'un `watch(queryParams, ...)` qui appelle `router.replace({ query: params })` à chaque changement, maintenant l'URL en sync.

## Impact

- Les liens partagés reflètent désormais l'état exact des filtres.
- Le bouton retour du navigateur restaure les filtres précédents.
- Aucun changement de comportement pour les utilisateurs qui n'utilisent pas les filtres.