### PR TITLE
fix: add labels to icon-only social link buttons on community page

### DIFF
--- a/app/pages/communautes/[slug].vue
+++ b/app/pages/communautes/[slug].vue
@@ -58,7 +58,11 @@
             variant="outline"
             color="neutral"
             size="sm"
-          />
+            :aria-label="`${community.name} sur YouTube`"
+            :title="`${community.name} sur YouTube`"
+          >
+            YouTube
+          </UButton>
           <UButton
             v-if="community.twitchUrl"
             :to="community.twitchUrl"
@@ -67,7 +71,11 @@
             variant="outline"
             color="neutral"
             size="sm"
-          />
+            :aria-label="`${community.name} sur Twitch`"
+            :title="`${community.name} sur Twitch`"
+          >
+            Twitch
+          </UButton>
           <UButton
             v-if="community.instagramUrl"
             :to="community.instagramUrl"
@@ -76,7 +84,11 @@
             variant="outline"
             color="neutral"
             size="sm"
-          />
+            :aria-label="`${community.name} sur Instagram`"
+            :title="`${community.name} sur Instagram`"
+          >
+            Instagram
+          </UButton>
           <UButton
             v-if="community.facebookUrl"
             :to="community.facebookUrl"
@@ -85,7 +97,11 @@
             variant="outline"
             color="neutral"
             size="sm"
-          />
+            :aria-label="`${community.name} sur Facebook`"
+            :title="`${community.name} sur Facebook`"
+          >
+            Facebook
+          </UButton>
           <UButton
             v-if="community.twitterUrl"
             :to="community.twitterUrl"
@@ -94,7 +110,11 @@
             variant="outline"
             color="neutral"
             size="sm"
-          />
+            :aria-label="`${community.name} sur X (Twitter)`"
+            :title="`${community.name} sur X (Twitter)`"
+          >
+            X
+          </UButton>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problème

Sur la page de détail d'une communauté (`/communautes/[slug]`), les boutons vers YouTube, Twitch, Instagram, Facebook et X n'avaient ni texte visible, ni `aria-label`, ni `title`. Un lecteur d'écran annonçait simplement « button » sans aucun contexte.

En comparaison, les boutons Discord et Site web portaient déjà un label textuel. L'incohérence rendait ces cinq liens inutilisables pour les utilisateurs qui dépendent de technologies d'assistance.

## Solution

Ajout d'un label textuel dans chaque bouton (cohérent avec Discord/Site web), ainsi qu'un `aria-label` et un `title` dynamiques incluant le nom de la communauté pour plus de précision.

## Avant / Après

| Avant | Après |
|-------|-------|
| Icône seule, pas de contexte | Icône + label « YouTube », « Twitch », etc. |
| Pas d'`aria-label` | `aria-label="[Commu] sur YouTube"` |
| Pas de `title` | Tooltip au survol |