### PR TITLE
feat: animate homepage stat counters with count-up on scroll

### DIFF
--- a/app/composables/useCountUp.ts
+++ b/app/composables/useCountUp.ts
@@ -1,0 +1,32 @@
+export function useCountUp(target: Ref<number>, duration = 900) {
+  const displayed = ref(0)
+  let rafId: number | null = null
+
+  function animate(from: number, to: number) {
+    if (rafId !== null) cancelAnimationFrame(rafId)
+    const start = performance.now()
+
+    function step(now: number) {
+      const elapsed = now - start
+      const progress = Math.min(elapsed / duration, 1)
+      // ease-out cubic
+      const eased = 1 - (1 - progress) ** 3
+      displayed.value = Math.round(from + (to - from) * eased)
+      if (progress < 1) {
+        rafId = requestAnimationFrame(step)
+      }
+    }
+
+    rafId = requestAnimationFrame(step)
+  }
+
+  watch(target, (to, from) => {
+    animate(from ?? 0, to)
+  })
+
+  onUnmounted(() => {
+    if (rafId !== null) cancelAnimationFrame(rafId)
+  })
+
+  return displayed
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -59,7 +59,7 @@
         >
           <div class="stat-counter-value">
             <template v-if="typeof stat.value === 'number'">
-              <span class="tabular-nums">{{ statsVisible ? stat.value : 0 }}</span>
+              <span class="tabular-nums">{{ stat.displayed }}</span>
             </template>
             <template v-else>
               {{ stat.value }}
@@ -330,7 +330,7 @@ async function goRandom() {
   if (data.value?.slug) navigateTo(`/communautes/${data.value.slug}`)
 }
 
-const heroStats = computed(() => {
+const rawStats = computed(() => {
   if (!stats.value) return []
   return [
     { value: stats.value.totalCommunities, label: 'Communautés' },
@@ -338,6 +338,27 @@ const heroStats = computed(() => {
     { value: stats.value.openRecruitment, label: 'Recrutent' },
     { value: stats.value.topModules?.[0]?.name || '—', label: 'Module #1' },
   ]
+})
+
+// Animated targets: only trigger when section becomes visible
+const countTargets = [ref(0), ref(0), ref(0)]
+const countDisplayed = countTargets.map(t => useCountUp(t))
+
+watch(statsVisible, (visible) => {
+  if (!visible) return
+  rawStats.value.forEach((stat, i) => {
+    if (typeof stat.value === 'number' && countTargets[i]) {
+      countTargets[i].value = stat.value
+    }
+  })
+})
+
+const heroStats = computed(() => {
+  if (!rawStats.value.length) return []
+  return rawStats.value.map((stat, i) => ({
+    ...stat,
+    displayed: typeof stat.value === 'number' ? countDisplayed[i]?.value ?? stat.value : stat.value,
+  }))
 })
 
 const discoverCards = [


### PR DESCRIPTION
## Contexte

Les quatre cartes de stats sur la homepage (`totalCommunities`, `totalModules`, `openRecruitment`, `Module #1`) passaient instantanément de 0 à leur valeur finale dès que la section entrait dans le viewport. L'`IntersectionObserver` et la classe `tabular-nums` étaient déjà en place, ce qui suggère qu'une animation était prévue mais jamais branchée.

## Solution

Nouveau composable `useCountUp(target, duration)` :
- Basé sur `requestAnimationFrame` — pas de dépendance externe
- Ease-out cubique pour un rendu naturel
- `onUnmounted` pour nettoyer le RAF en cas de navigation rapide

Côté homepage : les targets count-up sont alimentées uniquement quand `statsVisible` passe à `true` (scroll-in), les valeurs textuelles (Module #1) sont laissées intactes.

## Résultat

Les trois compteurs numériques s'incrémentent sur ~900ms à l'entrée dans le viewport.